### PR TITLE
 Fix realpath usage on macOS, use idiomatic paths.

### DIFF
--- a/dragonblocks.sh
+++ b/dragonblocks.sh
@@ -4,10 +4,17 @@ set -e
 
 script_name="$0"
 
-: "${DRAGONBLOCKS_DATA:=${XDG_DATA_HOME:-$HOME/.local/share}/dragonblocks_alpha}"
-: "${DRAGONBLOCKS_CONFIG:=${XDG_CONFIG_HOME:-$HOME/.config}/dragonblocks_alpha}"
-: "${DRAGONBLOCKS_TMP:=${XDG_RUNTIME_DIR:-/tmp}/dragonblocks_alpha}"
-: "${DRAGONBLOCKS_STATE:=${XDG_STATE_HOME:-$HOME/.local/state}/dragonblocks_alpha}"
+if [[ "$(uname)" == "Darwin" ]]; then
+	: "${DRAGONBLOCKS_DATA:=${HOME}/Library/Application Support/dragonblocks_alpha/data}"
+	: "${DRAGONBLOCKS_CONFIG:=${HOME}/Library/Application Support/dragonblocks_alpha/config}"
+	: "${DRAGONBLOCKS_TMP:=${TMPDIR:-/tmp}/dragonblocks_alpha}"
+	: "${DRAGONBLOCKS_STATE:=${HOME}/Library/Application Support/dragonblocks_alpha/state}"
+else
+	: "${DRAGONBLOCKS_DATA:=${XDG_DATA_HOME:-$HOME/.local/share}/dragonblocks_alpha}"
+	: "${DRAGONBLOCKS_CONFIG:=${XDG_CONFIG_HOME:-$HOME/.config}/dragonblocks_alpha}"
+	: "${DRAGONBLOCKS_TMP:=${XDG_RUNTIME_DIR:-/tmp}/dragonblocks_alpha}"
+	: "${DRAGONBLOCKS_STATE:=${XDG_STATE_HOME:-$HOME/.local/state}/dragonblocks_alpha}"
+fi
 
 mkdir -p "$DRAGONBLOCKS_DATA/"
 mkdir -p "$DRAGONBLOCKS_CONFIG/"

--- a/dragonblocks.sh
+++ b/dragonblocks.sh
@@ -77,8 +77,8 @@ get_world() {
 
 launch() {
 	local which="$1"
-	local config="$(realpath $DRAGONBLOCKS_CONFIG/$which.conf)"
-	local log="$(realpath $log_path/$which-$(timestamp).log)"
+	local config="$(realpath $DRAGONBLOCKS_CONFIG)/$which.conf"
+	local log="$(realpath $log_path)/$which-$(timestamp).log"
 	shift
 
 	cd "$version_working_dir"
@@ -149,7 +149,7 @@ EOF
 		world="$(get_world $2)"
 		load_version "$(<$world/version)"
 
-		addrfile="$(realpath $DRAGONBLOCKS_TMP/address-$(timestamp).fifo)"
+		addrfile="$(realpath $DRAGONBLOCKS_TMP)/address-$(timestamp).fifo"
 		mkfifo "$addrfile"
 
 		trap "unlaunch server" SIGINT SIGTERM


### PR DESCRIPTION
File has to exist for realpath to function, which the folder does but the file does not yet exist. realpath -E also does not exist.

Also adjusts the paths to be more idiomatic for macOS, however there are a handful of path quotation bugs where the path will be invalid due to the space in "Application Support"
